### PR TITLE
Allow some console statements to be preserved

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,20 @@ browserify main.js -t [stripify -r '(0)']
 var stripify = require("stripify")
 stripify("file.js", {replacement: '(0)'})
 ```
+
+### Preserving logs
+
+Sometimes we want to preserve certain console statements while stripping out other ones. Stripify supports this by expecting your console messages to begin with `!Stripify:Preserve!`.
+
+For example:
+
+```js
+console.log('!Stripify:Preserve!Keep this message');
+console.log('Remove this message');
+```
+
+Will become:
+
+```js
+console.log('Keep this message');
+```

--- a/test/expected/preserve.js
+++ b/test/expected/preserve.js
@@ -1,0 +1,5 @@
+console.log("foo");;
+;console.log("bar");
+;
+console.log("def");
+;

--- a/test/fixtures/preserve.js
+++ b/test/fixtures/preserve.js
@@ -1,0 +1,5 @@
+console.log("!Stripify:Preserve!foo");console.log("bar");
+console.log("foo");console.log("!Stripify:Preserve!bar");
+console.log("abc");
+console.log("!Stripify:Preserve!def");
+console.log("ghi");


### PR DESCRIPTION
This PR allows specific console statements to be preserved. We wanted this so we could use console.logs liberally through our codebase and have them stripped, but still allow very specific messages to be included for production.

In this PR, we look for console messages that begin with '!Stripify:Preserve!' to indicate which log messages should be preserved.
