### PR TITLE
Fix for ESLint for ES6 recommending not to use `console`

### DIFF
--- a/stripify.js
+++ b/stripify.js
@@ -39,7 +39,7 @@ function isConsoleLog (node) {
 function isConsole (node) {
   if (!node) return false
   if (node.type != "MemberExpression") return false
-  return node.object.type == "Identifier" && node.object.name == "console"
+  return node.object.type == "Identifier" && ( node.object.name == "console" || node.object.name == "Console" )
 }
 
 var consoleApi = ["assert", "count", "debug", "dir", "error", "exception", "group", "groupCollapsed", "groupEnd", "info", "log", "profile", "profileEnd", "time", "timeEnd", "trace", "warn", "table"]


### PR DESCRIPTION
ESLint for ES6 recommends not using `console` https://github.com/eslint/eslint/blob/master/docs/rules/no-console.md
Instead to declare `let Console = window.console;` and calling the console methods via `Console`. Edited the file to match both `Console` & `console`
