### PR TITLE
Allow filtering of console api methods

### DIFF
--- a/stripify.js
+++ b/stripify.js
@@ -6,6 +6,7 @@ module.exports = function (file, opts) {
 
   opts = opts || {}
   opts.replacement = opts.replacement || opts.r || ''
+  opts.methods = opts.methods || opts.m || consoleApi
 
   var data = ''
 
@@ -27,15 +28,15 @@ module.exports = function (file, opts) {
 
 function parse (data, opts) {
   return falafel(data, function (node) {
-    if (node.type !== 'DebuggerStatement' && (node.type !== 'CallExpression' || (!isConsoleLog(node.callee) && !isConsoleLogProto(node.callee)))) return
+    if (node.type !== 'DebuggerStatement' && (node.type !== 'CallExpression' || (!isConsoleMethod(node.callee, opts.methods) && !isConsoleMethodProto(node.callee, opts.methods)))) return
     node.update(opts.replacement)
   })
 }
 
-function isConsoleLogProto (node) {
+function isConsoleMethodProto (node, methods) {
   if (!node) return false
   if (node.type !== 'MemberExpression') return false
-  return isProto(node.property) && isConsoleLog(node.object)
+  return isProto(node.property) && isConsoleMethod(node.object, methods)
 }
 
 var functionProtoMethods = [ 'apply', 'call' ]
@@ -44,8 +45,8 @@ function isProto (node) {
   return node.type === 'Identifier' && (functionProtoMethods.indexOf(node.name) > -1)
 }
 
-function isConsoleLog (node) {
-  return isConsole(node) && isLog(node.property)
+function isConsoleMethod (node, methods) {
+  return isConsole(node) && isMethod(node.property, methods)
 }
 
 function isConsole (node) {
@@ -54,8 +55,8 @@ function isConsole (node) {
   return node.object.type === 'Identifier' && node.object.name === 'console'
 }
 
-var consoleApi = ['assert', 'count', 'debug', 'dir', 'error', 'exception', 'group', 'groupCollapsed', 'groupEnd', 'info', 'log', 'profile', 'profileEnd', 'time', 'timeEnd', 'trace', 'warn', 'table']
-
-function isLog (node) {
-  return node.type === 'Identifier' && (consoleApi.indexOf(node.name) > -1)
+function isMethod (node, methods) {
+  return node.type === 'Identifier' && (methods.indexOf(node.name) > -1)
 }
+
+var consoleApi = ['assert', 'count', 'debug', 'dir', 'error', 'exception', 'group', 'groupCollapsed', 'groupEnd', 'info', 'log', 'profile', 'profileEnd', 'time', 'timeEnd', 'trace', 'warn', 'table']

--- a/test/expected/methods.js
+++ b/test/expected/methods.js
@@ -1,0 +1,17 @@
+console.assert();
+console.count();
+console.debug();
+console.dir();
+console.error();
+console.exception();
+console.group();
+console.groupCollapsed();
+console.groupEnd();
+;
+;
+console.profile();
+console.profileEnd();
+console.time();
+console.timeEnd();
+console.trace();
+console.warn();

--- a/test/fixtures/methods.js
+++ b/test/fixtures/methods.js
@@ -1,0 +1,17 @@
+console.assert();
+console.count();
+console.debug();
+console.dir();
+console.error();
+console.exception();
+console.group();
+console.groupCollapsed();
+console.groupEnd();
+console.info();
+console.log();
+console.profile();
+console.profileEnd();
+console.time();
+console.timeEnd();
+console.trace();
+console.warn();

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,8 @@ var stripify = require('../')
 
 var files = fs.readdirSync(path.join(__dirname, 'fixtures'))
 var testOpts = {
-  'replacement.js': {r: '(0)'}
+  'replacement.js': {r: '(0)'},
+  'methods.js': {methods: ['log', 'info']}
 }
 
 files.forEach(function (file) {


### PR DESCRIPTION
Add parameter for specifying the particular console methods to be removed (eg. only remove "log" and "info" {methods: ["log", "info"]})
